### PR TITLE
fix: Check for a private key instead of public key

### DIFF
--- a/install
+++ b/install
@@ -3,7 +3,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 clone_install() {
   declare desc="generates an ssh keypair for the dokku user and checks installed correctly"
-  if [[ -f "$DOKKU_ROOT/.ssh/id_rsa.pub" ]]; then
+  if [[ -f "$DOKKU_ROOT/.ssh/id_rsa" ]]; then
     return;
   fi
   ssh-keygen -t rsa -N "" -q -f "$DOKKU_ROOT/.ssh/id_rsa"


### PR DESCRIPTION
Clones will work fine with if just a private key exists, which can be the case in certain cloud environments that use configuration management to provision keys.