### PR TITLE
fix: do not call dokku binary

### DIFF
--- a/functions
+++ b/functions
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
 clone_main_cmd() {
   declare desc="creates/updates app from remote git repo"
@@ -38,7 +39,7 @@ cat | DOKKU_ROOT="$DOKKU_ROOT" dokku git-hook $APP
 EOF
     chmod +x "$PRERECEIVE_HOOK"
 
-    dokku ps:rebuild "$APP"
+    ps_rebuild "$APP"
   fi
 }
 


### PR DESCRIPTION
This ensures we have compatibility with the latest Dokku release, where `ps:rebuild` does nothing if the app was never deployed.