### PR TITLE
Allow to pass port to clone:allow command

### DIFF
--- a/functions
+++ b/functions
@@ -56,7 +56,7 @@ clone_key_cmd() {
 
 clone_allow_cmd() {
   declare desc="adds a domain to known_hosts"
-  declare DOMAIN="$2" TAGNAME="${3:-22}"
+  declare DOMAIN="$2" PORT="${3:-22}"
   local cmd="$1"
 
   [[ -z $2 ]] && dokku_log_fail "Please supply a git domain ie 'dokku clone:allow github.com'"

--- a/functions
+++ b/functions
@@ -56,11 +56,11 @@ clone_key_cmd() {
 
 clone_allow_cmd() {
   declare desc="adds a domain to known_hosts"
-  declare DOMAIN="$2"
+  declare DOMAIN="$2" TAGNAME="${3:-22}"
   local cmd="$1"
 
   [[ -z $2 ]] && dokku_log_fail "Please supply a git domain ie 'dokku clone:allow github.com'"
 
-  ssh-keyscan -t rsa "$DOMAIN" >> "$DOKKU_ROOT/.ssh/known_hosts"
+  ssh-keyscan -t rsa -p "$PORT" "$DOMAIN" >> "$DOKKU_ROOT/.ssh/known_hosts"
   dokku_log_info1 "$DOMAIN added to known hosts"
 }


### PR DESCRIPTION
If you are running SSH on a different port then 22 this command would fail. I have added the optional argument to pass the port it will fallback to 22 when not given